### PR TITLE
`spack`: Add `${PUGIXML_INCLUDE_DIR}` to `target_include_directories`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,6 +101,7 @@ target_include_directories(fmi4cpp
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}
+        ${PUGIXML_INCLUDE_DIR}
 )
 
 target_link_libraries(fmi4cpp


### PR DESCRIPTION
@prudhomm 

When `pugixml` is not installed in a standard location (e.g. use `pugixml` build by `spack`),
the `include` directory needs to be added to the target's `include` directories

See the PR for adding a `feelpp` recipe into `spack` at https://github.com/spack/spack/pull/46396#pullrequestreview-2363892769 for more info.

A different way to do this would be like upstream does meanwhile:
https://github.com/NTNU-IHB/FMI4cpp/blob/71d30042e4044bdd12ccf9fa756046b801e46502/cmake/FindPugiXML.cmake#L26

See this for the diff:

https://github.com/feelpp/FMI4cpp/compare/master...NTNU-IHB%3AFMI4cpp%3Amaster#diff-2bd3d1ab5072e7e84c9bdea1f59038fda719facac5721f1ba2ee9a39eb139bfeR24-R28

Maybe it's better so sync / merge with the upstream?
